### PR TITLE
feat: Add toggle for broadcast view canvas border

### DIFF
--- a/src/pages/BroadcastView.tsx
+++ b/src/pages/BroadcastView.tsx
@@ -96,7 +96,7 @@ const BroadcastView: React.FC<BroadcastViewProps> = ({ targetCanvasId }) => {
         position: 'relative',
         overflow: 'hidden',
         backgroundColor: canvasToRender.backgroundColor || 'transparent', // Canvas background color remains
-        border: '1px dashed #777', // Added dotted border for clarity
+        border: canvasToRender.showBroadcastBorder === false ? '1px dashed transparent' : '1px dashed #777', // Conditional border
       }}
     >
       {/* Old direct background image rendering removed */}

--- a/src/pages/StudioInterface.tsx
+++ b/src/pages/StudioInterface.tsx
@@ -34,6 +34,7 @@ const StudioInterface: React.FC = () => {
     resetActiveCanvasLayout,
     setCanvasBackgroundColor,
     importLayoutsFromFile, // Added import action
+    toggleCanvasBroadcastBorder, // Added for border toggle
     // setCanvasBackgroundImage, // This action was removed from the store
   } = useDraftStore(state => state);
 
@@ -407,6 +408,24 @@ const StudioInterface: React.FC = () => {
                    <span style={{overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '100px', display: 'inline-block'}} title={canvas.name} > {canvas.name.length > 15 ? canvas.name.substring(0, 12) + '...' : canvas.name} </span>
                    <button title="Rename canvas" onClick={(e) => { e.stopPropagation(); setEditingCanvasId(canvas.id); setEditingCanvasName(canvas.name); }} style={{ background: 'transparent', border: 'none', color: '#ccc', padding: '0 5px', marginLeft: '5px', cursor: 'pointer', fontSize: '1em' }} > ✏️ </button>
                    <span title="Open canvas in new window (placeholder)" onClick={(e) => { e.stopPropagation(); const broadcastUrl = `/index.html?view=broadcast&canvasId=${canvas.id}`; window.open(broadcastUrl, '_blank'); console.log('Attempting to open broadcast view in new tab for canvas ID:', canvas.id, 'at URL:', broadcastUrl); }} style={{ width: '10px', height: '10px', backgroundColor: 'white', border: '1px solid #666', marginLeft: '8px', cursor: 'pointer', display: 'inline-block' }} ></span>
+                   <button
+                      title={canvas.showBroadcastBorder === false ? "Show broadcast border" : "Hide broadcast border"}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        toggleCanvasBroadcastBorder(canvas.id);
+                      }}
+                      style={{
+                        width: '12px',
+                        height: '12px',
+                        backgroundColor: canvas.showBroadcastBorder === false ? 'transparent' : 'black',
+                        border: `1px solid ${canvas.showBroadcastBorder === false ? '#888' : 'white'}`,
+                        marginLeft: '8px',
+                        cursor: 'pointer',
+                        display: 'inline-block',
+                        padding: 0,
+                        lineHeight: '10px', // Adjust for vertical centering if needed
+                      }}
+                    ></button>
                    {currentCanvases.length > 1 && ( <button title="Remove canvas" onClick={(e) => { e.stopPropagation(); if(confirm(`Are you sure you want to delete canvas "${canvas.name}"?`)) removeCanvas(canvas.id); }} style={{ background: 'transparent', border: 'none', color: '#aaa', marginLeft: '5px', cursor: 'pointer', fontSize: '1.2em', padding: '0 3px', lineHeight: '1', fontWeight: 'bold' }} > &times; </button> )}
                  </>
                )}

--- a/src/store/draftStore.ts
+++ b/src/store/draftStore.ts
@@ -85,6 +85,7 @@ interface DraftStore extends CombinedDraftState {
   setCanvasBackgroundColor: (canvasId: string, color: string | null) => void;
   // setCanvasBackgroundImage: (canvasId: string, imageUrl: string | null) => void; // To be removed
   setActiveStudioLayoutId: (layoutId: string | null) => void;
+  toggleCanvasBroadcastBorder: (canvasId: string) => void; // New action for toggling border
 
   // Import/Export Actions
   importLayoutsFromFile: (data: { savedStudioLayouts: SavedStudioLayout[], currentCanvases: StudioCanvas[], activeCanvasId: string | null }) => void;
@@ -106,6 +107,7 @@ const initialCanvases: StudioCanvas[] = [{
   name: 'Default',
   layout: [],
   backgroundColor: null,
+  showBroadcastBorder: true, // Default to true
   // backgroundImage: null, // Removed
 }];
 
@@ -2145,6 +2147,25 @@ const useDraftStore = create<DraftStore>()(
               };
             }
             return state; // Return original state if active canvas not found or no change made
+          });
+          get()._autoSaveOrUpdateActiveStudioLayout();
+        },
+
+        toggleCanvasBroadcastBorder: (canvasId: string) => {
+          set(state => {
+            const updatedCanvases = state.currentCanvases.map(canvas => {
+              if (canvas.id === canvasId) {
+                return { ...canvas, showBroadcastBorder: !(canvas.showBroadcastBorder === undefined ? true : canvas.showBroadcastBorder) };
+              }
+              return canvas;
+            });
+            // Check if a change actually occurred
+            const originalCanvas = state.currentCanvases.find(c => c.id === canvasId);
+            const updatedCanvas = updatedCanvases.find(c => c.id === canvasId);
+            if (originalCanvas && updatedCanvas && originalCanvas.showBroadcastBorder !== updatedCanvas.showBroadcastBorder) {
+              return { ...state, currentCanvases: updatedCanvases, layoutLastUpdated: Date.now() };
+            }
+            return state; // No change if canvas not found or value is the same
           });
           get()._autoSaveOrUpdateActiveStudioLayout();
         },

--- a/src/types/draft.ts
+++ b/src/types/draft.ts
@@ -142,5 +142,6 @@ export interface StudioCanvas {
   name: string; // User-friendly name for the tab, e.g., "Scene 1" or "Default"
   layout: StudioElement[]; // Array of elements on this canvas
   backgroundColor?: string | null;
+  showBroadcastBorder?: boolean; // Added for toggling broadcast view border
   // backgroundImage?: string | null; // Removed, will be handled by BackgroundImageElement
 }


### PR DESCRIPTION
Implemented a feature to toggle the visibility of the dashed border in the Broadcast View for each canvas.

- Updated `StudioCanvas` type to include `showBroadcastBorder`.
- Modified `draftStore` to initialize `showBroadcastBorder` and added an action `toggleCanvasBroadcastBorder`.
- Added a UI button in `StudioInterface` for each canvas tab to control this setting. The button's appearance reflects the current state.
- Updated `BroadcastView` to conditionally render the border based on the `showBroadcastBorder` property of the canvas.
- Ensured state persistence and correct behavior for new canvases.