### PR TITLE
feat: Separate 'Hide Game X Titles' from 'Hide Maps' in BoXSeriesOver…

### DIFF
--- a/src/components/studio/BoXSeriesOverviewElement.tsx
+++ b/src/components/studio/BoXSeriesOverviewElement.tsx
@@ -25,7 +25,8 @@ const BoXSeriesOverviewElement: React.FC<BoXSeriesOverviewElementProps> = ({ ele
     showMapNames = true,
     gameEntrySpacing = 10,
     hideCivs = false,
-    hideMaps = false, // Added hideMaps
+    hideMaps = false,
+    hideGameXText = false, // Added hideGameXText
     pivotInternalOffset = 0,
   } = element;
 
@@ -147,7 +148,7 @@ const BoXSeriesOverviewElement: React.FC<BoXSeriesOverviewElementProps> = ({ ele
 
         return (
          <div key={index} className={styles.gameEntryContainer} style={{ paddingTop: index > 0 ? `${gameEntrySpacing}px` : '0px' }}>
-            {!hideMaps && <div className={styles.gameTitle} style={dynamicGameTitleStyle}>Game {index + 1}</div>}
+            {!hideGameXText && <div className={styles.gameTitle} style={dynamicGameTitleStyle}>Game {index + 1}</div>}
             <div className={styles.gameImageRow} style={gameImageRowDynamicStyle}>
               {!hideCivs && (
                 <div className={`${styles.civCell} ${styles.leftCivCell}`}>

--- a/src/components/studio/SettingsPanel.tsx
+++ b/src/components/studio/SettingsPanel.tsx
@@ -131,6 +131,16 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ selectedElement, onClose 
            onChange={(e) => handleSettingChange('hideMaps', e.target.checked)}
          />
        </div>
+       <div style={settingRowStyle}>
+         <label htmlFor="boxHideGameXTextCheckbox" style={labelStyle}>Hide Game X Titles:</label>
+         <input
+           type="checkbox"
+           id="boxHideGameXTextCheckbox"
+           style={checkboxStyle}
+           checked={selectedElement.hideGameXText || false} // Default to false if undefined
+           onChange={(e) => handleSettingChange('hideGameXText', e.target.checked)}
+         />
+       </div>
         <div style={{ marginBottom: '12px' }}> {/* Game Spacing Slider from previous step */}
           <label
             htmlFor="boxGameSpacingSlider"

--- a/src/store/draftStore.ts
+++ b/src/store/draftStore.ts
@@ -1749,6 +1749,7 @@ const useDraftStore = create<DraftStore>()(
                 isPivotLocked: false,
                 hideCivs: false, // Added hideCivs default
                 hideMaps: false, // Added hideMaps default
+                hideGameXText: false, // Added hideGameXText default
                 // No showName or showScore here
               };
             } else if (elementType === "ScoreOnly") {

--- a/src/types/draft.ts
+++ b/src/types/draft.ts
@@ -80,6 +80,7 @@ export interface StudioElement {
   gameEntrySpacing?: number; // Vertical spacing between game entries in BoX overview
   hideCivs?: boolean; // New property for BoXSeriesOverview to hide civs
   hideMaps?: boolean; // New property for BoXSeriesOverview to hide maps
+  hideGameXText?: boolean; // New property for BoXSeriesOverview to hide "Game X" titles
   // showName and showScore removed
   imageUrl?: string | null; // For BackgroundImageElement
   opacity?: number;         // For BackgroundImageElement


### PR DESCRIPTION
…view

Introduced a new 'Hide Game X Titles' checkbox in the SettingsPanel for the BoXSeriesOverview element. This allows users to toggle the visibility of the 'Game X' titles independently of the map column.

- Added `hideGameXText` property to the `StudioElement` type.
- Initialized `hideGameXText: false` for new BoXSeriesOverview elements.
- Added a dedicated checkbox in `SettingsPanel.tsx` for this new option.
- Modified `BoXSeriesOverviewElement.tsx` to use `hideGameXText` for the conditional rendering of game titles, decoupling it from `hideMaps`.