### PR TITLE
Add game visibility toggle for BoX Series Overview

### DIFF
--- a/src/components/studio/BoXSeriesOverviewElement.tsx
+++ b/src/components/studio/BoXSeriesOverviewElement.tsx
@@ -34,6 +34,9 @@ const BoXSeriesOverviewElement: React.FC<BoXSeriesOverviewElementProps> = ({ ele
     boxSeriesGames: state.boxSeriesGames,
   }));
 
+  // Filter games based on the isVisible flag
+  const visibleGames = boxSeriesGames.filter(game => game.isVisible === undefined ? false : game.isVisible);
+
   const REFERENCE_SELECTOR_HEIGHT_UNSCALED_PX = 30;
   const BASELINE_FONT_SIZE_UNSCALED_PX = 10;
   const dynamicFontSize = BASELINE_FONT_SIZE_UNSCALED_PX;
@@ -96,17 +99,25 @@ const BoXSeriesOverviewElement: React.FC<BoXSeriesOverviewElementProps> = ({ ele
     fontFamily: gameTitleFont,
   };
 
-  if (!boxSeriesGames || boxSeriesGames.length === 0) {
+  if (!visibleGames || visibleGames.length === 0) { // Use visibleGames here
     if (isBroadcast) return null;
-    return <div className={styles.noGamesMessage} style={{ fontFamily }}>(BoX Series: No Games)</div>;
+    return <div className={styles.noGamesMessage} style={{ fontFamily }}>(BoX Series: No Visible Games)</div>; // Updated message
   }
 
   return (
     <div className={styles.baseElement} style={{ fontFamily, fontSize: `${dynamicFontSize}px` }}>
-      {boxSeriesGames.map((game: BoxSeriesGame, index: number) => {
-        const hostCivKey = `hc-${index}-${game.hostCiv || 'random'}`;
-        const mapKey = `map-${index}-${game.map || 'random'}`;
-        const guestCivKey = `gc-${index}-${game.guestCiv || 'random'}`;
+      {visibleGames.map((game: BoxSeriesGame, index: number) => { // Use visibleGames here
+        // Note: The 'index' here is for the visibleGames array. If the original index is needed for Game X text,
+        // and we want to preserve original numbering (e.g. Game 1, Game 3 if Game 2 is hidden),
+        // we would need to find the original index from boxSeriesGames.
+        // For now, assuming Game {index + 1} refers to the sequence of VISIBLE games.
+        // If original game numbering is critical even when some are hidden, this logic will need adjustment.
+        // Based on "Игры в элементе Box Series Overview на странице Broadcast Studio должны продолжать подстраиваться относительно центра",
+        // re-numbering based on visible games seems acceptable.
+
+        const hostCivKey = `hc-${game.hostCiv || 'random'}-${index}`; // Ensure key uniqueness with potentially sparse original indices
+        const mapKey = `map-${game.map || 'random'}-${index}`;
+        const guestCivKey = `gc-${game.guestCiv || 'random'}-${index}`;
 
         // Opacity states for the <img> overlay fade-in effect
         const [hostCivImgOpacity, setHostCivImgOpacity] = useState(0);

--- a/src/pages/TechnicalInterface.tsx
+++ b/src/pages/TechnicalInterface.tsx
@@ -39,6 +39,7 @@ const TechnicalInterface = () => {
     saveCurrentAsPreset, loadPreset, deletePreset,
     _resetCurrentSessionState,
     setBoxSeriesFormat, updateBoxSeriesGame, setGameWinner,
+    toggleBoxSeriesGameVisibility, // Added new action
   } = useDraftStore();
 
   const playerColors = ['#00C4FF', '#FF9500', '#A64DFF', '#1E3A8A', '#FF0000', '#FF69B4', '#FFFF00', '#00FF00'];
@@ -765,7 +766,19 @@ const COUNTRY_PLAYERS_FILE_PATH = 'assets/countryflags/countryplayers.txt';
             <div className="box-games-list">
               {boxSeriesGames.map((game, index) => (
                 <div key={index} className="box-game-slot">
-                  <h4 className="game-slot-title">Game {index + 1}</h4>
+                  <div style={{ display: 'flex', alignItems: 'center', marginBottom: '5px' }}>
+                    <h4 className="game-slot-title" style={{ marginRight: '10px', marginBottom: '0' }}>Game {index + 1}</h4>
+                    <label htmlFor={`game-visible-checkbox-${index}`} style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', fontSize: '0.9em' }}>
+                      <input
+                        type="checkbox"
+                        id={`game-visible-checkbox-${index}`}
+                        checked={game.isVisible === undefined ? false : game.isVisible}
+                        onChange={() => toggleBoxSeriesGameVisibility(index)}
+                        style={{ marginRight: '5px' }}
+                      />
+                      Show Game
+                    </label>
+                  </div>
                   <div className="game-slot-selectors">
                     <div className="selector-group">
                       <label htmlFor={`box-host-civ-${index}`} className={game.winner === 'host' ? 'text-winner' : game.winner === 'guest' ? 'text-loser' : ''}>

--- a/src/types/draft.ts
+++ b/src/types/draft.ts
@@ -19,6 +19,7 @@ export interface BoxSeriesGame {
   hostCiv: string | null;
   guestCiv: string | null;
   winner: 'host' | 'guest' | null;
+  isVisible?: boolean; // Added to control visibility in Broadcast Studio
 }
 
 export interface Aoe2cmRawDraftData {


### PR DESCRIPTION
Implemented a feature to control the visibility of individual games (Game 1, Game 2, etc.) in the BoX Series Overview element on the Broadcast Studio page.

Changes include:
- Added an `isVisible` boolean property to the `BoxSeriesGame` type.
- Updated the `draftStore` to manage this new property:
    - Games are initialized with `isVisible: false` (hidden) by default.
    - Presets correctly save and load the `isVisible` state; older presets default games to hidden.
    - Added `toggleBoxSeriesGameVisibility` action.
- Modified `TechnicalInterface.tsx` to include a 'Show Game' checkbox for each game in the BoX Series Overview data input card.
- Updated `BoXSeriesOverviewElement.tsx` on the Broadcast Studio page to only render games marked as visible.
- Ensured existing game centering logic adapts to visible games.
- Tested functionality for creating series, toggling visibility, saving/loading presets, and changing series format.