### PR TITLE
Update: Default game visibility to true (visible)

### DIFF
--- a/src/pages/TechnicalInterface.tsx
+++ b/src/pages/TechnicalInterface.tsx
@@ -770,11 +770,11 @@ const COUNTRY_PLAYERS_FILE_PATH = 'assets/countryflags/countryplayers.txt';
                     <input
                       type="checkbox"
                       id={`game-visible-checkbox-${index}`}
-                      checked={game.isVisible === undefined ? false : game.isVisible}
+                      checked={game.isVisible} // Simplified: game.isVisible should always be a boolean from the store
                       onChange={() => toggleBoxSeriesGameVisibility(index)}
-                      style={{ marginRight: '8px', transform: 'scale(1.1)' }} // Added some margin and slight scale
+                      style={{ marginRight: '8px', transform: 'scale(1.1)' }}
                     />
-                    <h4 className="game-slot-title" style={{ margin: '0', fontWeight: 'normal', fontSize: '1em' }}>Game {index + 1}</h4> {/* Removed default h4 margin, adjusted font */}
+                    <h4 className="game-slot-title" style={{ margin: '0', fontWeight: 'normal', fontSize: '1em' }}>Game {index + 1}</h4>
                   </label>
                   <div className="game-slot-selectors">
                     <div className="selector-group">


### PR DESCRIPTION
Changed the default behavior for BoX series game visibility. Games are now visible by default when a new series is created, when games are added by changing format, or when loading older\presets that do not have visibility information.

- Updated `draftStore.ts` to initialize `BoxSeriesGame.isVisible` to `true` in relevant functions (`_calculateUpdatedBoxSeriesGames`, `setBoxSeriesFormat`, `loadPreset`).
- Ensured `TechnicalInterface.tsx` checkbox reflects this new default.
- Tested new default behavior across different scenarios.