### PR TITLE
Feat: Add fade-in animation for new draft items

### DIFF
--- a/src/components/studio/GeneralElements.module.css
+++ b/src/components/studio/GeneralElements.module.css
@@ -231,3 +231,16 @@
   font-size: 1.5em;
   font-weight: bold;
 }
+
+@keyframes longFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.longFadeIn {
+  animation: longFadeIn 1.5s ease-in-out forwards;
+}

--- a/src/hooks/useDraftAnimation.ts
+++ b/src/hooks/useDraftAnimation.ts
@@ -55,7 +55,7 @@ const useDraftAnimation = (
 
   if (itemIsTheLastAction) {
     return {
-      animationClass: 'fadeIn',
+      animationClass: 'longFadeIn',
       imageOpacity: 1,
       isRevealing: false,
     };


### PR DESCRIPTION
This change introduces a 1.5s fade-in animation for newly picked or banned icons in the draft view. The animation is triggered by the lastDraftAction state, ensuring that only the most recent item is animated.